### PR TITLE
Introduce CI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: nix
+
+script:
+- nix-build --arg coq-version "\"$COQ_VERSION\"" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+
+env:
+  - COQ_VERSION=master
+  - COQ_VERSION=v8.8
+  - COQ_VERSION=8.8

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,30 @@
+{ pkgs ? (import <nixpkgs> {}), coq-version ? "master" }:
+
+let
+ coq =
+   if coq-version == "8.8" then pkgs.coq_8_8
+   else import (fetchTarball "https://github.com/coq/coq/tarball/${coq-version}") {};
+
+ mathcomp =
+   if coq-version == "8.8" then pkgs.coqPackages_8_8.mathcomp
+   else import ./mathcomp.nix { inherit pkgs coq; };
+in
+
+pkgs.stdenv.mkDerivation rec {
+
+  name = "lemma-overloading";
+
+  buildInputs = [ coq mathcomp ];
+
+  src = ./.;
+
+  makeFlags =
+    if coq-version == "8.8" then ""
+    else "COQPATH=${mathcomp}/lib/coq/user-contrib/";
+
+  installFlags = "COQLIB=$(out)/lib/coq/";
+
+  shellHook =
+    if coq-version == "8.8" then ""
+    else "export COQPATH=${mathcomp}/lib/coq/user-contrib/$\{COQPATH:+:$COQPATH}";
+}

--- a/default.nix
+++ b/default.nix
@@ -5,26 +5,26 @@ let
    if coq-version == "8.8" then pkgs.coq_8_8
    else import (fetchTarball "https://github.com/coq/coq/tarball/${coq-version}") {};
 
- mathcomp =
-   if coq-version == "8.8" then pkgs.coqPackages_8_8.mathcomp
-   else import ./mathcomp.nix { inherit pkgs coq; };
+ ssreflect =
+   if coq-version == "8.8" then pkgs.coqPackages_8_8.ssreflect
+   else import ./ssreflect.nix { inherit pkgs coq; };
 in
 
 pkgs.stdenv.mkDerivation rec {
 
   name = "lemma-overloading";
 
-  buildInputs = [ coq mathcomp ];
+  buildInputs = [ coq ssreflect ];
 
   src = ./.;
 
   makeFlags =
     if coq-version == "8.8" then ""
-    else "COQPATH=${mathcomp}/lib/coq/user-contrib/";
+    else "COQPATH=${ssreflect}/lib/coq/user-contrib/";
 
   installFlags = "COQLIB=$(out)/lib/coq/";
 
   shellHook =
     if coq-version == "8.8" then ""
-    else "export COQPATH=${mathcomp}/lib/coq/user-contrib/$\{COQPATH:+:$COQPATH}";
+    else "export COQPATH=${ssreflect}/lib/coq/user-contrib/$\{COQPATH:+:$COQPATH}";
 }

--- a/mathcomp.nix
+++ b/mathcomp.nix
@@ -1,0 +1,10 @@
+{ pkgs ? (import <nixpkgs> {}), coq }:
+
+pkgs.stdenv.mkDerivation rec {
+  name = "mathcomp";
+  buildInputs = [ coq pkgs.which ];
+  src = "${fetchTarball https://github.com/math-comp/math-comp/tarball/master}/mathcomp";
+  installPhase = ''
+    make -f Makefile.coq COQLIB=$out/lib/coq/ install
+  '';
+}

--- a/ssreflect.nix
+++ b/ssreflect.nix
@@ -1,10 +1,10 @@
 { pkgs ? (import <nixpkgs> {}), coq }:
 
 pkgs.stdenv.mkDerivation rec {
-  name = "mathcomp";
+  name = "ssreflect";
   buildInputs = [ coq pkgs.which ];
   src = "${fetchTarball https://github.com/math-comp/math-comp/tarball/master}/mathcomp";
-  installPhase = ''
-    make -f Makefile.coq COQLIB=$out/lib/coq/ install
-  '';
+  configurePhase = "make Makefile.coq";
+  buildPhase = "make -f Makefile.coq ssreflect/all_ssreflect.vo";
+  installPhase = "make -f Makefile.coq COQLIB=$out/lib/coq/ install";
 }


### PR DESCRIPTION
This is a first step, but it's already useful as-is.

For now the build time is about 30 minutes (includes math-comp).
I intend to try avoiding rebuilding math-comp when it is not necessary (when it has not changed and neither has Coq).
Coq itself is not compiled most of the time because we use a binary cache that is populated by Coq CI (the only exception is when Coq has just been updated and the CI hasn't produced the Nix package yet).

I'll open a more general coq-community issue to discuss these caching questions.