### PR TITLE
squash non-example admits

### DIFF
--- a/theories/domains.v
+++ b/theories/domains.v
@@ -1285,7 +1285,7 @@ Qed.
 Definition kleene_lfp := lim pow_chain.
 
 Lemma kleene_lfp_fixed : f kleene_lfp = kleene_lfp.
-Proof. try by rewrite contE lim_liftE; apply: limE; rewrite reindex. Admitted.
+Proof. by rewrite (@contE _ _ f) lim_liftE; apply: limE; rewrite reindex. Qed.
 
 Lemma kleene_lfp_least : forall x, f x = x -> kleene_lfp <== x.
 Proof.

--- a/theories/stlog.v
+++ b/theories/stlog.v
@@ -387,16 +387,10 @@ Ltac hstep :=
   end.
 
 Lemma swp : forall (A : Type) (v : A) x h, h \In x :--> v <-> h = x :-> v.
-Proof.
-move=>A v x h; split; first by admit.
-by move=>->; rewrite InE /pts /=; unlock.
-Admitted.
+Proof. by move=>A v x h; split; rewrite InE /pts /=; unlock. Qed.
 
 Lemma opn : forall (A : Type) (v : A) x h, h \In x :--> v <-> x :-> v = h.
-Proof.
-move=>A v x h; split=>[|H]; first by admit. (* case; unlock. *)
-by rewrite InE /= /pts; unlock.
-Admitted.
+Proof. by move=>A v x h; split=>[|H]; rewrite InE /= /pts; unlock. Qed.
 
 Prenex Implicits swp opn.
 


### PR DESCRIPTION
As far as I can see, remaining admits are for examples/testing.