### PR TITLE
CI update: more uniformity and opam package testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,42 @@ script:
 
 matrix:
   include:
+
+  # Test supported versions of Coq
   - env: COQ=https://github.com/coq/coq/tarball/master
-  - env: COQ=8.8
   - env: COQ=8.9
+  - env: COQ=8.8
+
+  # Test opam package
+  - language: minimal
+    sudo: required
+    services: docker
+    env:
+    - COQ_IMAGE=coqorg/coq:dev
+    - CONTRIB_NAME=lemma-overloading
+    - NJOBS=2
+    install: |
+      # Prepare the COQ container
+      docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+      docker exec COQ /bin/bash --login -c "
+        # This bash script is double-quoted to interpolate Travis CI env vars:
+        echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+        set -ex  # -e = exit on failure; -x = trace for debug
+        opam update -y
+        opam install -y -j ${NJOBS} --deps-only .
+        opam config list
+        opam repo list
+        opam list
+        "
+    script:
+    - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+    - |
+      docker exec COQ /bin/bash --login -c "
+        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+        set -ex
+        sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
+        opam install -y -j ${NJOBS} .
+        "
+    - docker stop COQ  # optional
+    - echo -en 'travis_fold:end:script\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: nix
 
 script:
-- nix-build --arg coq-version "\"$COQ_VERSION\"" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
 
-env:
-  - COQ_VERSION=master
-  - COQ_VERSION=8.8
-  - COQ_VERSION=8.9
+matrix:
+  include:
+  - env: COQ=https://github.com/coq/coq/tarball/master
+  - env: COQ=8.8
+  - env: COQ=8.9


### PR DESCRIPTION
This PR contains several updates to the CI infrastructure:

- update of the Nix setup to take advantage of recent improvements and towards more uniformity (see also the equivalent PR on aac-tactics coq-community/aac-tactics#21), cc @vbgl
- add a test of the opam package using the Docker image by @erikmd (cc @palmskog)

The goal is to add templates in https://github.com/coq-community/manifesto/tree/master/templates based on this setup. That's why I tried to make sure that the two projects had a setup that was as close as possible.