### PR TITLE
_CoqProject: fix for CoqIDE

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,8 @@
 -Q theories LemmaOverloading
--arg "-w -notation-overridden,-projection-no-head-constant,-redundant-canonical-projection"
+
+-arg -w -arg -notation-overridden
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -redundant-canonical-projection
 
 theories/prelude.v
 theories/rels.v


### PR DESCRIPTION
With this workaround the build system, ProofGeneral, and CoqIDE are able
to read `_CoqProject` file correctly.
See https://github.com/coq/coq/issues/5773