### PR TITLE
Make core hint database usage explicit

### DIFF
--- a/theories/domains.v
+++ b/theories/domains.v
@@ -102,7 +102,7 @@ Proof. by case: T y x z=>S [[l b B R A Tr]] ? x y z; apply: (Tr). Qed.
 
 End Laws.
 
-Hint Resolve botP poset_refl.
+Hint Resolve botP poset_refl : core.
 
 Add Parametric Relation (T : poset) : T (@Poset.leq T)
   reflexivity proved by (@poset_refl _)

--- a/theories/heaps.v
+++ b/theories/heaps.v
@@ -310,7 +310,7 @@ Qed.
 Lemma def0 : def empty.
 Proof. by []. Qed.
 
-Hint Resolve def0.
+Hint Resolve def0 : core.
 
 Lemma defU h x d : def (upd h x d) = (x != null) && (def h).
 Proof.
@@ -644,7 +644,7 @@ Proof. by rewrite -lt0n addn1. Qed.
 
 Opaque fresh.
 
-Hint Resolve dom_fresh fresh_null.
+Hint Resolve dom_fresh fresh_null : core.
 
 (********)
 (* pick *)
@@ -757,7 +757,7 @@ apply/subdomP=>[//||x in1]; first by apply negbT.
 by apply: (subdomQ H2) (subdomQ H1 in1).
 Qed.
 
-Hint Resolve subdom_emp subdomPE.
+Hint Resolve subdom_emp subdomPE : core.
 
 (***********)
 (* subheap *)
@@ -1199,7 +1199,7 @@ Notation "h1 =~ h2" := (loweq h1 h2) (at level 80).
 Lemma low_refl h : h =~ h.
 Proof. by rewrite /loweq. Qed.
 
-Hint Resolve low_refl.
+Hint Resolve low_refl : core.
 
 Lemma low_sym h1 h2 : (h1 =~ h2) = (h2 =~ h1).
 Proof. by rewrite /loweq eq_sym. Qed.
@@ -1247,7 +1247,7 @@ Qed.
 Lemma lowPn A1 A2 (x : ptr) (v1 : A1) (v2 : A2) : x :-> v1 =~ x :-> v2.
 Proof. by apply/loweqP=>y; rewrite !ldomP !domPt. Qed.
 
-Hint Resolve lowPn.
+Hint Resolve lowPn : core.
 
 Lemma highPn A1 A2 (x1 x2 : ptr) (v1 : A1) (v2 : A2) :
         high x1 -> high x2 -> x1 :-> v1 =~ x2 :-> v2.

--- a/theories/perms.v
+++ b/theories/perms.v
@@ -59,7 +59,7 @@ elim:s=>[|e s IH]; first by apply: permutation_nil.
 by apply: (permutation_skip (x:=e)) IH.
 Qed.
 
-Hint Resolve perm_refl.
+Hint Resolve perm_refl : core.
 
 Lemma perm_sym s1 s2 : perm s1 s2 <-> perm s2 s1.
 Proof.
@@ -124,7 +124,7 @@ apply: (@perm_trans (y::x::s2++s1)); first by apply: permutation_swap eq_refl.
 by apply: permutation_skip IH2.
 Qed.
 
-Hint Resolve perm_catC.
+Hint Resolve perm_catC : core.
 
 Lemma perm_cons_catCA s1 s2 x : perm (x :: s1 ++ s2) (s1 ++ x :: s2).
 Proof.
@@ -135,7 +135,7 @@ Qed.
 Lemma perm_cons_catAC s1 s2 x : perm (s1 ++ x :: s2) (x :: s1 ++ s2).
 Proof. by apply/perm_sym; apply: perm_cons_catCA. Qed.
 
-Hint Resolve perm_cons_catCA perm_cons_catAC.
+Hint Resolve perm_cons_catCA perm_cons_catAC : core.
 
 Lemma perm_cons_cat_consL s1 s2 s x :
         perm s (s1 ++ s2) -> perm (x :: s) (s1 ++ x :: s2).
@@ -260,4 +260,4 @@ Proof. by move=>*; rewrite !catA perm_cat2r. Qed.
 End Permutations.
 
 Hint Resolve perm_refl perm_catC perm_cons_catCA
-             perm_cons_catAC perm_catAC perm_catCA.
+             perm_cons_catAC perm_catAC perm_catCA : core.

--- a/theories/prefix.v
+++ b/theories/prefix.v
@@ -82,4 +82,4 @@ Qed.
 
 End Prefix.
 
-Hint Resolve prefix_refl.
+Hint Resolve prefix_refl : core.

--- a/theories/prelude.v
+++ b/theories/prelude.v
@@ -162,7 +162,7 @@ Proof. by move=>pf; rewrite eqc. Qed.
 
 End Coercions.
 
-Hint Resolve jmeq_refl.
+Hint Resolve jmeq_refl : core.
 Arguments jmeq T [A B] x y.
 Notation "a =jm b" := (jmeq id a b) (at level 50).
 
@@ -209,7 +209,7 @@ Proof. by move=>pf; rewrite eqc2. Qed.
 
 End Coercions2.
 
-Hint Resolve refl_jmeq2.
+Hint Resolve refl_jmeq2 : core.
 Arguments jmeq2 T [A1 A2 B1 B2] x y.
 
 (***************************)

--- a/theories/rels.v
+++ b/theories/rels.v
@@ -289,7 +289,7 @@ Definition EqPredType_trans r2 r1 r3 := @EqPredType_trans' r1 r2 r3.
 Definition SubPredType_trans r2 r1 r3 := @SubPredType_trans' r1 r2 r3.
 End RelProperties.
 
-Hint Resolve EqPredType_refl SubPredType_refl.
+Hint Resolve EqPredType_refl SubPredType_refl : core.
 
 (* Declaration of relations *)
 
@@ -458,7 +458,7 @@ Proof. by move=>H x [H1 H2]; split; [|apply: H]. Qed.
 
 End SubMemLaws.
 
-Hint Resolve subp_refl.
+Hint Resolve subp_refl : core.
 
 Section ListMembership.
 Variable T : Type.

--- a/theories/stlog.v
+++ b/theories/stlog.v
@@ -401,13 +401,13 @@ Prenex Implicits swp opn.
 Lemma blah (A : Type) (p : ptr) (l : A) : def (p :-> l) -> (p :-> l) \In p :--> l.
 Proof. by move=>H; apply/swp. Qed.
 
-Hint Immediate blah.
+Hint Immediate blah : core.
 
 Lemma blah2 (A : Type) (v1 v2 : A) q :
         def (q :-> v1) -> v1 = v2 -> q :-> v1 \In q :--> v2.
 Proof. by move=>D E; apply/swp; rewrite E. Qed.
 
-Hint Immediate blah2.
+Hint Immediate blah2 : core.
 
 Ltac hauto := (do ?econstructor=>//;
                 try by [defcheck; auto |

--- a/theories/stmod.v
+++ b/theories/stmod.v
@@ -409,7 +409,7 @@ Definition conseq A (s1 s2 : spec A) :=
 Lemma conseq_refl (A : Type) (s : spec A) : conseq s s.
 Proof. by []. Qed.
 
-Hint Resolve conseq_refl.
+Hint Resolve conseq_refl : core.
 
 Section Consequence.
 Variables (A : Type) (s1 s2 : spec A) (e : ST s1) (pf : conseq s1 s2).

--- a/theories/stsep.v
+++ b/theories/stsep.v
@@ -154,7 +154,7 @@ Local Notation conseq1 :=
 Lemma conseq_refl A (s : spec A) : conseq1 A s s.
 Proof. by case: s=>s1 s2 i H; apply: frame0. Qed.
 
-Hint Resolve conseq_refl.
+Hint Resolve conseq_refl : core.
 
 Section SepConseq.
 Variables (A : Type) (s1 s2 : spec A) (e : STsep s1).


### PR DESCRIPTION
This fixes a bunch of warnings emitted by the future Coq 8.10:

```
Warning: Adding and removing hints in the core database implicitly is
deprecated. Please specify a hint database.
[implicit-core-hint-db,deprecated]
```