### PR TITLE
Add copyright header in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,15 @@
+Copyright (C) 2012 G. Gonthier, B. Ziliani, A. Nanevski, D. Dreyer
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
 ### GNU GENERAL PUBLIC LICENSE
 
 Version 3, 29 June 2007


### PR DESCRIPTION
Although `LICENSE.md` contains the definition of GPL3, only source files indicate that this project is actually licensed under [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html) and not `GPL-3.0-only`. Here, I include a copyright header and make the license precise in `LICENSE.md`.

The [GitHub help page](https://help.github.com/articles/licensing-a-repository/) on licenses seems to indicate that it's preferred to have a copyright header and precise license definition in the LICENSE file.

Thoughts @anton-trunov?