### PR TITLE
Pin nixpkgs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Makefile.coq.conf
 *.aux
 *.glob
 *.vo
+result

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,61 @@
-language: nix
+opam: &OPAM
+  language: minimal
+  sudo: required
+  services: docker
+  install: |
+    # Prepare the COQ container
+    docker pull ${COQ_IMAGE}
+    docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+    docker exec COQ /bin/bash --login -c "
+      # This bash script is double-quoted to interpolate Travis CI env vars:
+      echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex  # -e = exit on failure; -x = trace for debug
+      opam update -y
+      opam pin add ${CONTRIB_NAME} . -y --no-action
+      opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
+      opam config list
+      opam repo list
+      opam list
+      "
+  script:
+  - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+  - |
+    docker exec COQ /bin/bash --login -c "
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex
+      sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
+      opam install ${CONTRIB_NAME} -v -y -j ${NJOBS}
+      "
+  - docker stop COQ  # optional
+  - echo -en 'travis_fold:end:script\\r'
 
-script:
-- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
+nix: &NIX
+  language: nix
+  script:
+  - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
 matrix:
   include:
 
-  # Test supported versions of Coq
-  - env: COQ=https://github.com/coq/coq-on-cachix/tarball/master
-  - env: COQ=8.9
-  - env: COQ=8.8
+  # Test supported versions of Coq via Nix
+  - env:
+    - COQ=https://github.com/coq/coq-on-cachix/tarball/master
+    <<: *NIX
+  - env:
+    - COQ=https://github.com/coq/coq-on-cachix/tarball/v8.10
+    <<: *NIX
+  - env:
+    - COQ=8.9
+    <<: *NIX
+  - env:
+    - COQ=8.8
+    <<: *NIX
 
-  # Test opam package
-  - language: minimal
-    sudo: required
-    services: docker
-    env:
+  # Test supported versions of Coq via OPAM
+  - env:
     - COQ_IMAGE=coqorg/coq:dev
-    - CONTRIB_NAME=lemma-overloading
+    - CONTRIB_NAME=coq-lemma-overloading
     - NJOBS=2
-    install: |
-      # Prepare the COQ container
-      docker pull ${COQ_IMAGE}
-      docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
-      docker exec COQ /bin/bash --login -c "
-        # This bash script is double-quoted to interpolate Travis CI env vars:
-        echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
-        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-        set -ex  # -e = exit on failure; -x = trace for debug
-        opam update -y
-        opam install -y -j ${NJOBS} --deps-only .
-        opam config list
-        opam repo list
-        opam list
-        "
-    script:
-    - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
-    - |
-      docker exec COQ /bin/bash --login -c "
-        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-        set -ex
-        sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
-        opam install -v -y -j ${NJOBS} .
-        "
-    - docker stop COQ  # optional
-    - echo -en 'travis_fold:end:script\\r'
+    <<: *OPAM
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ opam: &OPAM
 nix: &NIX
   language: nix
   script:
-  - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
+  - nix-build --arg pkgs "import (fetchTarball https://github.com/NixOS/nixpkgs/tarball/b02b4e12c5e1ebde582eb77fc9808faca4d662f1) {}" --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 [![Gitter][gitter-shield]][gitter-link]
 [![DOI][doi-shield]][doi-link]
 
-[doi-shield]: https://zenodo.org/badge/DOI/10.1017/S0956796813000051.svg
-[doi-link]: https://doi.org/10.1017/S0956796813000051
-
 [travis-shield]: https://travis-ci.com/coq-community/lemma-overloading.svg?branch=master
 [travis-link]: https://travis-ci.com/coq-community/lemma-overloading/builds
 
@@ -20,6 +17,9 @@
 
 [gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
 [gitter-link]: https://gitter.im/coq-community/Lobby
+
+[doi-shield]: https://zenodo.org/badge/DOI/10.1017/S0956796813000051.svg
+[doi-link]: https://doi.org/10.1017/S0956796813000051
 
 This project contains Hoare Type Theory libraries which
 demonstrate a series of design patterns for programming
@@ -41,20 +41,19 @@ More details about the project can be found in the paper
   - Beta Ziliani (initial)
   - Aleksandar Nanevski (initial)
   - Derek Dreyer (initial)
-- Maintainer(s):
+- Coq-community maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU General Public License v3.0 or later](LICENSE.md)
 - Compatible Coq versions: Coq 8.8 or later (use releases for other Coq versions)
-- Additional dependencies:
+- Additional Coq dependencies:
   - [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or later (`ssreflect` suffices)
-
 
 
 ## Building and installation instructions
 
-The easiest way to install the latest released version is via
-[OPAM](https://opam.ocaml.org/doc/Install.html):
+The easiest way to install the latest released version of Lemma overloading
+is via [OPAM](https://opam.ocaml.org/doc/Install.html):
 
 ```shell
 opam repo add coq-released https://coq.inria.fr/opam/released
@@ -72,6 +71,7 @@ make install
 
 After installation, the included modules are available under
 the `LemmaOverloading` namespace.
+
 
 ## Files described in the paper
 

--- a/meta.yml
+++ b/meta.yml
@@ -2,8 +2,11 @@
 fullname: Lemma overloading
 shortname: lemma-overloading
 organization: coq-community
+community: true
 
-synopsis: Libraries demonstrating design patterns for programming and proving with canonical structures in Coq
+synopsis: >-
+  Libraries demonstrating design patterns for programming and proving
+  with canonical structures in Coq
 
 description: |
   This project contains Hoare Type Theory libraries which
@@ -47,17 +50,19 @@ supported_coq_versions:
   text: Coq 8.8 or later (use releases for other Coq versions)
   opam: '{(>= "8.8" & < "8.10~") | (= "dev")}'
 
-tested_coq_versions:
+tested_coq_nix_versions:
 - version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/v8.10
 - version_or_url: 8.9
 - version_or_url: 8.8
 
-tested_coq_opam_version: dev
+tested_coq_opam_versions:
+- version: dev
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "1.7.0" & < "1.8~") | (= "dev")}'
+    version: '{(>= "1.7.0" & < "1.9~") | (= "dev")}'
   nix: ssreflect
   description: |
     [MathComp](https://math-comp.github.io/math-comp/) 1.7.0 or later (`ssreflect` suffices)

--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ flags: light-uninstall
 depends: [
   "ocaml"
   "coq" {(>= "8.8" & < "8.10~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.7.0" & < "1.8~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.7.0" & < "1.9~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
This PR pins nixpkgs to a future version to fix the Nix CI build for Coq master. Indeed, so far it is trying to  build math-comp's ssreflect 1.7.0 which is not compatible with Coq 8.10 / Coq master.
This PR also updates `meta.yml` and the various generated files according to the latest versions of the templates.
Finally, it adds testing with Coq v8.10 and declares compatibility with math-comp's ssreflect 1.8.0.