### PR TITLE
Don't ignore duplicate-clear errors

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -5,7 +5,6 @@
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -undeclared-scope
--arg -w -arg -duplicate-clear
 
 theories/prelude.v
 theories/rels.v

--- a/theories/domains.v
+++ b/theories/domains.v
@@ -517,8 +517,8 @@ Proof. by move=>t H1 H2 p; move/(_ _ H1 H2). Qed.
 Lemma sup_closP (s : Pred T) : sup_closed (sup_closure s).
 Proof.
 split; first by move=>t _ [].
-move=>d H1 t H3 H4; move: (sup_clos_min H3 H4)=>{H3} H3.
-by case: H4=>_; apply=>// x; move/H1; move/H3.
+move=>d H1 t /sup_clos_min H3 H4.
+by case: (H4) => _; apply=> x /H1/(H3 H4).
 Qed.
 
 Lemma sup_clos_idemp (s : Pred T) : sup_closed s -> sup_closure s =p s.
@@ -1142,8 +1142,8 @@ Proof. by move=>H1 H2 p; move/(_ _ H1 H2). Qed.
 Lemma chain_closP (s : Pred T) : chain_closed (chain_closure s).
 Proof.
 split; first by move=>t _ [].
-move=>d H1 t H3 H4; move: (chain_clos_min H3 H4)=>{H3} H3.
-by case: H4=>_; apply=>// x; move/H1; move/H3.
+move=>d H1 t /chain_clos_min H3 H4.
+by case: (H4) => _; apply=> x /H1/(H3 H4).
 Qed.
 
 Lemma chain_clos_idemp (s : Pred T) :

--- a/theories/heaps.v
+++ b/theories/heaps.v
@@ -898,7 +898,7 @@ Lemma cancel A h1 h2 x (v1 v2 : A) :
 Proof.
 move=>D E.
 have: look x (x :-> v1 :+ h1) = look x (x :-> v2 :+ h2) by rewrite E.
-rewrite !lookPtUn -?E // => X; move: (dyn_inj X)=>{X} X.
+rewrite !lookPtUn -?E // => /dyn_inj X.
 by rewrite -{}X in E *; rewrite -(unhKl D E) (defUnr D).
 Qed.
 
@@ -1001,9 +1001,9 @@ Qed.
 Lemma updi_inv x xs1 xs2 :
         def (updi x xs1) -> updi x xs1 = updi x xs2 -> xs1 = xs2.
 Proof.
-elim: xs1 x xs2 =>[|v1 xs1 IH] x /=; case=>[|v2 xs2] //= D;
-[move/esym| | ]; try by rewrite empbE empUn empPt.
-by case/(cancel D)=><- {D} D; move/(IH _ _ D)=><-.
+elim: xs1 x xs2 =>[|v1 xs1 IH] x /=; case=>[|v2 xs2 D] //=;
+try by move/esym; rewrite empbE empUn empPt.
+by case/(cancel D)=><- /IH E /E->.
 Qed.
 
 Lemma updi_iinv x xs1 xs2 h1 h2 :
@@ -1012,8 +1012,7 @@ Lemma updi_iinv x xs1 xs2 h1 h2 :
 Proof.
 elim: xs1 x xs2 h1 h2=>[|v1 xs1 IH] x /=; case=>[|v2 xs2] //= h1 h2.
 - by rewrite !un0h.
-move=>[E]; rewrite -!unA=>D; case/(cancel D)=><- {D} D.
-by case/(IH _ _ _ _ E D)=>->->.
+by case=>E; rewrite -!unA=>D; case/(cancel D)=><- /IH F /F - /(_ E) [->->].
 Qed.
 
 End BlockUpdate.
@@ -1158,16 +1157,8 @@ case=>x; rewrite inE /low /high /= -!topredE /=.
 by case: x=>// n; case E: (0 %% 2 == _)=>//=; rewrite -(eqP E).
 Qed.
 
-
 Lemma modnS x1 x2 : (x1 == x2 %[mod 2]) = (x1.+1 == x2.+1 %[mod 2]).
-Proof.
-case E: (x1 %% 2 == _).
-- by rewrite -addn1 -modnDm (eqP E) modnDm addn1 eq_refl.
-suff L: ((x1.+1) %% 2 == (x2.+1) %% 2) -> (x1 %% 2 == x2 %% 2).
-- by rewrite E in L; case: eqP L=>// _; apply.
-move=>{E} E; rewrite -(modnDr x1) -(modnDr x2).
-by rewrite -addSnnS -modnDm (eqP E) modnDm addSnnS.
-Qed.
+Proof. by rewrite -![_.+1 as X in X %% 2]add1n eqn_modDl. Qed.
 
 Lemma hlE x : high x = ~~ low x.
 Proof.


### PR DESCRIPTION
Coq 8.10 treats duplicate-clear warnings as errors.
We solve this in a backward-compatible way (supposed to supersede PR #34)