### PR TITLE
Remove the option turning warnings into errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Remove the option turning warnings into errors
 
 ## [8.12.0] - 2020-08-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ re-implementations for comparison.
   - Beta Ziliani (initial)
   - Aleksandar Nanevski (initial)
   - Derek Dreyer (initial)
-
 - Coq-community maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
 - License: [GNU General Public License v3.0 or later](LICENSE.md)

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,5 @@
 -Q theories LemmaOverloading
 
--arg -w -arg +default
 -arg -w -arg -notation-overridden
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -redundant-canonical-projection

--- a/theories/dune
+++ b/theories/dune
@@ -3,7 +3,6 @@
  (package coq-lemma-overloading)
  (synopsis "Libraries demonstrating design patterns for programming and proving with canonical structures in Coq")
  (flags
-   -w +default
    -w -notation-overridden
    -w -projection-no-head-constant
    -w -redundant-canonical-projection


### PR DESCRIPTION
This is because when Coq's master branch introduces new warnings
lemma-overloading causes Coq\'s CI to fail