### PR TITLE
Fix w.r.t. math-comp/math-comp#601 which renames `eq_sorted(_irr)` to `sorted_eq(_irr)`

### DIFF
--- a/theories/heaps.v
+++ b/theories/heaps.v
@@ -1196,7 +1196,7 @@ case E: (loweq h1 h2); constructor; rewrite /loweq in E.
 - by move=>x; rewrite /ldom (eqP E).
 move=>F.
 suff {E} : get_lows h1 = get_lows h2 by move/eqP; rewrite E.
-apply: (eq_sorted_irr (leT := ord)); last by apply: F.
+apply: (@eq_sorted_irr _ ord); last by apply: F.
 - by apply: trans.
 - by apply: irr.
 - case: h1 {F}=>// [[h S] H].


### PR DESCRIPTION
We are about to rename `eq_sorted` lemmas to `sorted_eq` to address a naming inconsistency in MathComp (see https://github.com/math-comp/math-comp/pull/601#issuecomment-705046342). Unfortunately, this deprecation breaks fcsl-pcm and lemma-overloading because the deprecation facility of MathComp does not support the `(ident := term)` syntax for explicit applications. As a workaround, I propose to use `@` syntax instead.