### PR TITLE
adjust mathcomp version boundaries, use mathcomp docker in CI

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -1,4 +1,6 @@
-name: CI
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+name: Docker CI
 
 on:
   push:
@@ -15,11 +17,12 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
-          - 'coqorg/coq:8.13'
-          - 'coqorg/coq:8.12'
-          - 'coqorg/coq:8.11'
-          - 'coqorg/coq:8.10'
+          - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.13'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.12'
+          - 'mathcomp/mathcomp:1.11.0-coq-8.12'
+          - 'mathcomp/mathcomp:1.10.0-coq-8.11'
+          - 'mathcomp/mathcomp:1.9.0-coq-8.10'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
+<!---
+This file was generated from `meta.yml`, please do not edit manually.
+Follow the instructions on https://github.com/coq-community/templates to regenerate.
+--->
 # Lemma Overloading
 
-[![CI][action-shield]][action-link]
+[![Docker CI][docker-action-shield]][docker-action-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Zulip][zulip-shield]][zulip-link]
 [![coqdoc][coqdoc-shield]][coqdoc-link]
 [![DOI][doi-shield]][doi-link]
 
-[action-shield]: https://github.com/coq-community/lemma-overloading/workflows/CI/badge.svg?branch=master
-[action-link]: https://github.com/coq-community/lemma-overloading/actions?query=workflow%3ACI
+[docker-action-shield]: https://github.com/coq-community/lemma-overloading/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/coq-community/lemma-overloading/actions?query=workflow:"Docker%20CI"
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
@@ -46,7 +50,7 @@ re-implementations for comparison.
 - License: [GNU General Public License v3.0 or later](LICENSE.md)
 - Compatible Coq versions: 8.10 or later (use releases for other Coq versions)
 - Additional dependencies:
-  - [MathComp](https://math-comp.github.io) 1.7.0 or later (`ssreflect` suffices)
+  - [MathComp](https://math-comp.github.io) 1.9.0 or later (`ssreflect` suffices)
 - Coq namespace: `LemmaOverloading`
 - Related publication(s):
   - [How to make ad hoc proof automation less ad hoc](https://software.imdea.org/~aleks/papers/lessadhoc/journal.pdf) doi:[10.1017/S0956796813000051](https://doi.org/10.1017/S0956796813000051)

--- a/coq-lemma-overloading.opam
+++ b/coq-lemma-overloading.opam
@@ -1,3 +1,6 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
 opam-version: "2.0"
 maintainer: "palmskog@gmail.com"
 version: "dev"
@@ -23,7 +26,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.7" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.9" & < "1.13~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -57,19 +57,26 @@ supported_coq_versions:
   opam: '{(>= "8.10" & < "8.14~") | (= "dev")}'
 
 tested_coq_opam_versions:
-- version: dev
-- version: '8.13'
-- version: '8.12'
-- version: '8.11'
-- version: '8.10'
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
+- version: '1.12.0-coq-8.13'
+  repo: 'mathcomp/mathcomp'
+- version: '1.12.0-coq-8.12'
+  repo: 'mathcomp/mathcomp'
+- version: '1.11.0-coq-8.12'
+  repo: 'mathcomp/mathcomp'
+- version: '1.10.0-coq-8.11'
+  repo: 'mathcomp/mathcomp'
+- version: '1.9.0-coq-8.10'
+  repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "1.7" & < "1.13~") | (= "dev")}'
+    version: '{(>= "1.9" & < "1.13~") | (= "dev")}'
   nix: ssreflect
   description: |-
-    [MathComp](https://math-comp.github.io) 1.7.0 or later (`ssreflect` suffices)
+    [MathComp](https://math-comp.github.io) 1.9.0 or later (`ssreflect` suffices)
 
 namespace: LemmaOverloading
 


### PR DESCRIPTION
This should make CI quite a lot faster. No point in allowing a version of MathComp not compatible with Coq >= 8.10.