### PR TITLE
Fix w.r.t. the removal of `eq_sorted_irr` in MathComp

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -22,7 +22,7 @@ jobs:
           - 'mathcomp/mathcomp:1.12.0-coq-8.12'
           - 'mathcomp/mathcomp:1.11.0-coq-8.12'
           - 'mathcomp/mathcomp:1.10.0-coq-8.11'
-          - 'mathcomp/mathcomp:1.9.0-coq-8.10'
+          - 'mathcomp/mathcomp:1.10.0-coq-8.10'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A lemma `ord_sorted_eq` in `heaps.v`
 ### Changed
 - Remove the option turning warnings into errors
+### Removed
+- Support for MathComp 1.9.0
 
 ## [8.12.0] - 2020-08-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- A lemma `ord_sorted_eq` in `heaps.v`
 ### Changed
 - Remove the option turning warnings into errors
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ re-implementations for comparison.
 - License: [GNU General Public License v3.0 or later](LICENSE.md)
 - Compatible Coq versions: 8.10 or later (use releases for other Coq versions)
 - Additional dependencies:
-  - [MathComp](https://math-comp.github.io) 1.9.0 or later (`ssreflect` suffices)
+  - [MathComp](https://math-comp.github.io) 1.10.0 or later (`ssreflect` suffices)
 - Coq namespace: `LemmaOverloading`
 - Related publication(s):
   - [How to make ad hoc proof automation less ad hoc](https://software.imdea.org/~aleks/papers/lessadhoc/journal.pdf) doi:[10.1017/S0956796813000051](https://doi.org/10.1017/S0956796813000051)

--- a/coq-lemma-overloading.opam
+++ b/coq-lemma-overloading.opam
@@ -26,7 +26,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.9" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.10" & < "1.13~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -67,16 +67,16 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.10.0-coq-8.11'
   repo: 'mathcomp/mathcomp'
-- version: '1.9.0-coq-8.10'
+- version: '1.10.0-coq-8.10'
   repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "1.9" & < "1.13~") | (= "dev")}'
+    version: '{(>= "1.10" & < "1.13~") | (= "dev")}'
   nix: ssreflect
   description: |-
-    [MathComp](https://math-comp.github.io) 1.9.0 or later (`ssreflect` suffices)
+    [MathComp](https://math-comp.github.io) 1.10.0 or later (`ssreflect` suffices)
 
 namespace: LemmaOverloading
 

--- a/theories/heaps.v
+++ b/theories/heaps.v
@@ -611,13 +611,13 @@ Qed.
 
 Lemma path_filter (A : ordType) (s : seq A) (p : pred A) x :
         path ord x s -> path ord x (filter p s).
-Proof.
-elim: s x=>[|y s IH] x //=.
-case/andP=>H1 H2.
-case: ifP=>E; first by rewrite /= H1 IH.
-apply: IH; elim: s H2=>[|z s IH] //=.
-by case/andP=>H2 H3; rewrite (@trans _ y).
-Qed.
+Proof. exact/path_filter/trans. Qed.
+
+Lemma ord_sorted_eq (A : ordType) (s1 s2 : seq A) :
+  sorted ord s1 -> sorted ord s2 -> s1 =i s2 -> s1 = s2.
+(* When dropping the compatibility with MathComp 1.11.0: *)
+(* Proof. exact/irr_sorted_eq/irr/trans. Qed. *)
+Proof. by [apply/irr_sorted_eq/irr/trans | apply/eq_sorted_irr/irr/trans]. Qed.
 
 Lemma dom_fresh h n : (fresh h).+n \notin dom h.
 Proof.
@@ -662,8 +662,7 @@ Proof. by case: h1 h2=>[|h1 H1] // [|h2 H2]. Qed.
 
 Lemma subdomP h1 h2 :
         def h1 -> ~~ empb h1 ->
-        reflect (forall x, x \in dom h1 -> x \in dom h2)
-                (subdom h1 h2).
+        reflect {subset dom h1 <= dom h2} (subdom h1 h2).
 Proof.
 case: h1 h2=>[|h1 H1] // [|h2 H2] //= _ H3; last by apply: allP.
 apply: ReflectF.
@@ -684,7 +683,7 @@ Proof. by case: h=>[//|h H _]; apply/allP. Qed.
 
 Lemma subdomD h1 h2 h : subdom h1 h2 -> def (h2 :+ h) -> def (h1 :+ h).
 Proof.
-case: h1 h2 h=>[|h1 H1]; case=>[|h2 H2]; case=>[|h H] //=.
+case: h1 h2 h=>[|h1 H1] [|h2 H2] [|h H] //=.
 rewrite /subdom /def /union2 /=; case: ifP=>E1 //; case: ifP=>E2 // E _.
 case: disjP E2=>// x H3 H4 _; case: disjP E1=>// X1 _.
 by case: (allP (s := supp h1)) E=>//; move/(_ _ H3); move/X1; rewrite H4.
@@ -693,7 +692,7 @@ Qed.
 Lemma subdomE h1 h2 h :
         def (h2 :+ h) -> subdom h1 h2 -> subdom (h1 :+ h) (h2 :+ h).
 Proof.
-case: h1 h2 h=>[|h1 H1]; case=>[|h2 H2]; case=>[|h H] //=.
+case: h1 h2 h=>[|h1 H1] [|h2 H2] [|h H] //=.
 rewrite /union2 /subdom /def /=; case: ifP=>E1 // _; case: ifP=>E2;
 case: (allP (s:=supp h1))=>// E _; last first.
 - case: disjP E2=>// x H3 H4; move/E: H3.
@@ -707,8 +706,7 @@ Lemma subdomUE h1 h2 h1' h2' :
         def (h2 :+ h2') -> subdom h1 h2 -> subdom h1' h2' ->
           subdom (h1 :+ h1') (h2 :+ h2').
 Proof.
-case: h1 h2 h1' h2'=>[|h1 H1]; case=>[|h2 H2];
-case=>[|h1' H1']; case=>[|h2' H2'] //.
+case: h1 h2 h1' h2'=>[|h1 H1] [|h2 H2] [|h1' H1'] [|h2' H2'] //.
 rewrite /subdom /def /union2.
 case: ifP=>E1 // _; case: ifP=>E2 // T1 T2; last first.
 - case: disjP E2=>// x; case: allP T1=>// X _; move/X=>{X}.
@@ -1196,10 +1194,8 @@ case E: (loweq h1 h2); constructor; rewrite /loweq in E.
 - by move=>x; rewrite /ldom (eqP E).
 move=>F.
 suff {E} : get_lows h1 = get_lows h2 by move/eqP; rewrite E.
-apply: (@eq_sorted_irr _ ord); last by apply: F.
-- by apply: trans.
-- by apply: irr.
-- case: h1 {F}=>// [[h S] H].
+apply: ord_sorted_eq; last by apply: F.
+  case: h1 {F}=>// [[h S] H].
   by rewrite sorted_filter //; apply: trans.
 case: h2 {F}=>// [[h S] H].
 by rewrite sorted_filter //; apply: trans.


### PR DESCRIPTION
- Context: `eq_sorted_irr` has been deprecated and renamed to `irr_sorted_eq` in MathComp 1.12.0 (see math-comp/math-comp#646), and this deprecation alias will be removed in MathComp 1.13.0 (see math-comp/math-comp#727).
- This change replaces the use of `eq_sorted_irr` with a new lemma `ord_sorted_eq`, which is `irr_sorted_eq` specialized to `ordType` and also serves as a compatibility layer for MathComp 1.11.0.