### PR TITLE
Fix

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,25 +18,16 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:2.0.0-coq-8.16'
-          - 'mathcomp/mathcomp:2.0.0-coq-8.17'
-          - 'mathcomp/mathcomp:2.0.0-coq-8.18'
-          - 'mathcomp/mathcomp:2.1.0-coq-8.16'
-          - 'mathcomp/mathcomp:2.1.0-coq-8.17'
-          - 'mathcomp/mathcomp:2.1.0-coq-8.18'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.16'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.17'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.18'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.19'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.20'
-          - 'mathcomp/mathcomp:2.2.0-coq-dev'
-          - 'mathcomp/mathcomp-dev:coq-8.18'
-          - 'mathcomp/mathcomp-dev:coq-8.19'
-          - 'mathcomp/mathcomp-dev:coq-8.20'
-          - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
+          - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.1'
+          - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.0'
+          - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.1'
+          - 'mathcomp/mathcomp-dev:rocq-prover-9.0'
+          - 'mathcomp/mathcomp-dev:rocq-prover-9.1'
+          - 'mathcomp/mathcomp-dev:rocq-prover-dev'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-lemma-overloading.opam'

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ re-implementations for comparison.
   - Beta Ziliani (initial)
   - Aleksandar Nanevski (initial)
   - Derek Dreyer (initial)
-- Coq-community maintainer(s):
+- Rocq-community maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
 - License: [GNU General Public License v3.0 or later](LICENSE.md)
-- Compatible Coq versions: 8.16 or later (use releases for other Coq versions)
+- Compatible Rocq/Coq versions: 9.0 or later (use releases for other Rocq/Coq versions)
 - Additional dependencies:
-  - [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.5.0 or later
-  - [MathComp](https://math-comp.github.io) 2.0.0 or later (`ssreflect` suffices)
-- Coq namespace: `LemmaOverloading`
+  - [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.7.0 or later
+  - [MathComp](https://math-comp.github.io) 2.4.0 or later (`ssreflect` suffices)
+- Rocq/Coq namespace: `LemmaOverloading`
 - Related publication(s):
   - [How to make ad hoc proof automation less ad hoc](https://software.imdea.org/~aleks/papers/lessadhoc/journal.pdf) doi:[10.1017/S0956796813000051](https://doi.org/10.1017/S0956796813000051)
   - [Structuring the verification of heap-manipulating programs](https://software.imdea.org/~aleks/papers/reflect/reflect.pdf) doi:[10.1145/1706299.1706331](https://doi.org/10.1145/1706299.1706331)
@@ -63,15 +63,19 @@ The easiest way to install the latest released version of Lemma Overloading
 is via [OPAM](https://opam.ocaml.org/doc/Install.html):
 
 ```shell
-opam repo add coq-released https://coq.inria.fr/opam/released
+opam repo add rocq-released https://rocq-prover.org/opam/released
 opam install coq-lemma-overloading
 ```
 
-To instead build and install manually, do:
+To instead build and install manually, you need to make sure that all the
+libraries this development depends on are installed.  The easiest way to do that
+is still to rely on opam:
 
 ``` shell
 git clone https://github.com/coq-community/lemma-overloading.git
 cd lemma-overloading
+opam repo add rocq-released https://rocq-prover.org/opam/released
+opam install --deps-only .
 make   # or make -j <number-of-cores-on-your-machine> 
 make install
 ```

--- a/coq-lemma-overloading.opam
+++ b/coq-lemma-overloading.opam
@@ -25,9 +25,9 @@ re-implementations for comparison."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16"}
-  "coq-hierarchy-builder" {>= "1.5.0"}
-  "coq-mathcomp-ssreflect" {>= "2.0"}
+  "coq" {>= "9.0"}
+  "coq-hierarchy-builder" {>= "1.7.0"}
+  "coq-mathcomp-ssreflect" {>= "2.4"}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -53,55 +53,37 @@ license:
   file: LICENSE.md
 
 supported_coq_versions:
-  text: 8.16 or later (use releases for other Coq versions)
-  opam: '{>= "8.16"}'
+  text: 9.0 or later (use releases for other Rocq/Coq versions)
+  opam: '{>= "9.0"}'
 
 tested_coq_opam_versions:
-- version: '2.0.0-coq-8.16'
+- version: '2.4.0-rocq-prover-9.0'
   repo: 'mathcomp/mathcomp'
-- version: '2.0.0-coq-8.17'
+- version: '2.4.0-rocq-prover-9.1'
   repo: 'mathcomp/mathcomp'
-- version: '2.0.0-coq-8.18'
+- version: '2.5.0-rocq-prover-9.0'
   repo: 'mathcomp/mathcomp'
-- version: '2.1.0-coq-8.16'
+- version: '2.5.0-rocq-prover-9.1'
   repo: 'mathcomp/mathcomp'
-- version: '2.1.0-coq-8.17'
-  repo: 'mathcomp/mathcomp'
-- version: '2.1.0-coq-8.18'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.16'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.17'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.18'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.19'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.20'
-  repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-dev'
-  repo: 'mathcomp/mathcomp'
-- version: 'coq-8.18'
+- version: 'rocq-prover-9.0'
   repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.19'
+- version: 'rocq-prover-9.1'
   repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.20'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-dev'
+- version: 'rocq-prover-dev'
   repo: 'mathcomp/mathcomp-dev'
 
 dependencies:
 - opam:
     name: coq-hierarchy-builder
-    version: '{>= "1.5.0"}'
+    version: '{>= "1.7.0"}'
   description: |-
-    [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.5.0 or later
+    [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.7.0 or later
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{>= "2.0"}'
+    version: '{>= "2.4"}'
   nix: ssreflect
   description: |-
-    [MathComp](https://math-comp.github.io) 2.0.0 or later (`ssreflect` suffices)
+    [MathComp](https://math-comp.github.io) 2.4.0 or later (`ssreflect` suffices)
 
 namespace: LemmaOverloading
 

--- a/resources/index.md
+++ b/resources/index.md
@@ -1,4 +1,6 @@
 ---
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
 title: Lemma Overloading
 lang: en
 header-includes:
@@ -10,9 +12,9 @@ header-includes:
     <style type="text/css"> body { width: 1100px; margin-left: 30px; }</style>
 ---
 
-<div style="text-align:left"><img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px">
-[View the project on GitHub](https://github.com/coq-community/lemma-overloading)
-<img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px"></div>
+<div style="text-align:left"><img src="https://gist.github.com/johan/1007813/raw/a25829510f049194b6404a8f98d22978e8744a6f/octocat.svg" height="25" style="border:0px">
+<a href="https://github.com/coq-community/lemma-overloading">View the project on GitHub</a>
+<img src="https://gist.github.com/johan/1007813/raw/a25829510f049194b6404a8f98d22978e8744a6f/octocat.svg" height="25" style="border:0px"></div>
 
 ## About
 
@@ -53,7 +55,10 @@ Other related publications, if any, are listed below.
 
 ## Authors and contributors
 
-- Georges Gonthier
-- Beta Ziliani
-- Aleksandar Nanevski
-- Derek Dreyer
+- Georges Gonthier (initial)
+- Beta Ziliani (initial)
+- Aleksandar Nanevski (initial)
+- Derek Dreyer (initial)
+
+
+

--- a/theories/domains.v
+++ b/theories/domains.v
@@ -52,7 +52,7 @@ Local Coercion sort : type >-> Sortclass.
 
 Variables (T : Type) (cT : type).
 Definition class := let: Pack _ c _ as cT' := cT return class_of cT' in c.
-Definition clone c of phant_id class c := @Pack T c T.
+Definition clone c & phant_id class c := @Pack T c T.
 
 (* produce a poset type out of the mixin *)
 (* equalize m0 and m by means of a phantom *)
@@ -385,7 +385,7 @@ Local Coercion sort : type >-> Sortclass.
 
 Variables (T : Type) (cT : type).
 Definition class := let: Pack _ c _ as cT' := cT return class_of cT' in c.
-Definition clone c of phant_id class c := @Pack T c T.
+Definition clone c & phant_id class c := @Pack T c T.
 
 (* produce a lattice type out of the mixin *)
 (* equalize m0 and m by means of a phantom *)
@@ -951,7 +951,7 @@ Local Coercion sort : type >-> Sortclass.
 
 Variables (T : Type) (cT : type).
 Definition class := let: Pack _ c _ as cT' := cT return class_of cT' in c.
-Definition clone c of phant_id class c := @Pack T c T.
+Definition clone c & phant_id class c := @Pack T c T.
 
 Definition pack b0 (m0 : mixin_of (Poset.Pack b0 T)) :=
   fun m & phant_id m0 m => Pack (@Class T b0 m) T.

--- a/theories/finmap.v
+++ b/theories/finmap.v
@@ -34,7 +34,7 @@ Structure finMap : Type := FinMap {
   seq_of : seq (K * V);
   _ : sorted ord (map key seq_of)}.
 
-Definition finMap_for of phant (K -> V) := finMap.
+Definition finMap_for & phant (K -> V) := finMap.
 
 Identity Coercion finMap_for_finMap : finMap_for >-> finMap.
 End Def.

--- a/theories/ordtype.v
+++ b/theories/ordtype.v
@@ -16,12 +16,13 @@
 *)
 
 From HB Require Import structures.
-From mathcomp Require Import ssreflect ssrbool ssrnat eqtype ssrfun seq fintype.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
+From mathcomp Require Import fintype.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-HB.mixin Record isTotalOrder T of Equality T := {
+HB.mixin Record isTotalOrder T & Equality T := {
   ord : rel T;
   irr : irreflexive ord;
   trans : transitive ord;

--- a/theories/prefix.v
+++ b/theories/prefix.v
@@ -61,7 +61,7 @@ Proof. by split=>E n; [apply: (E n.+1) | case: n]. Qed.
 Lemma prefix_cons' x y s1 s2 : prefix (x :: s1) (y :: s2) -> x = y /\ prefix s1 s2.
 Proof.
 move=>H; move: (H 0 x (erefl _))=>[H'].
-by move: H; rewrite H' prefix_cons.
+by move: H; rewrite H' => /prefix_cons.
 Qed.
 
 Lemma prefix_size (s t : seq A) : prefix s t -> size s <= size t.

--- a/theories/xfindCTC.v
+++ b/theories/xfindCTC.v
@@ -42,7 +42,7 @@ Next Obligation. by split; [|apply: prefix_refl]. Qed.
 Program Instance recurse_struct A (y:A) t e (f : XFind t e) :
   XFind (y :: t) e | 2 := {| seq_of := (y :: seq_of); index_of := index_of.+1|}.
 Next Obligation.
-by case:f=>r i /= [H1 H2]; split; [|apply/prefix_cons].
+by move=> A y t e [r i]/= [H1 H2]; split; last apply/prefix_cons.
 Qed.
 
 #[export]


### PR DESCRIPTION
Currently, Lemma Overloading does not compile with Rocq 9.0, MathComp 2.3, and HB 1.8.1.
```
Error:
HB: choice.hasChoice.axioms_ is not a factory or its library (mathcomp.ssreflect.choice) was not correctly imported
```