### PR TITLE
Restore historical ssreflect rewrite goal ordering

### DIFF
--- a/theories/prelude.v
+++ b/theories/prelude.v
@@ -17,6 +17,13 @@
 
 From Coq Require Import Eqdep ClassicalFacts.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype seq.
+
+(* This development relies on the historical goal order of conditional
+   ssreflect rewrites (main goal first, side conditions last), which
+   MathComp <= 2.5.0 used to enable globally on our behalf.  MathComp dev
+   no longer sets the option, so set it here for the whole library. *)
+#[global] Set SsrOldRewriteGoalsOrder.
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.


### PR DESCRIPTION
MathComp dev no longer globally enables `SsrOldRewriteGoalsOrder`, but several proofs rely on the former conditional-rewrite goal ordering. This change enables the option globally in `prelude.v`, which is imported throughout the library.

A clean `make -j8` completes against Rocq dev and MathComp dev in the `rocq-dev-testing` opam switch, with deprecation warnings but no errors.

The compatibility change was developed by a Claude coding-agent session and independently reviewed and validated by OpenAI Codex.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*

Wordsmithed by Codex.
